### PR TITLE
feat: include README.md in release archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,8 @@ jobs:
             [ -d ".claude/agents" ] && cp -r .claude/agents release-temp/
             # Copy commands directory
             [ -d ".claude/commands" ] && cp -r .claude/commands release-temp/
+            # Copy README.md to commands/han-solo directory for documentation
+            [ -f "README.md" ] && mkdir -p release-temp/commands/han-solo && cp README.md release-temp/commands/han-solo/README.md
             # Explicitly exclude settings.local.json
             find release-temp -name "settings.local.json" -delete 2>/dev/null || true
           else


### PR DESCRIPTION
## Summary
Enhances release archives by including documentation directly with the commands.

## Changes
- 📚 Copy README.md to `commands/han-solo/` directory in releases
- 📦 Users get complete documentation alongside command files
- 🎯 Better context for users downloading releases

## Impact
- Release archives now contain:
  - `/agents/` - Agent implementations
  - `/commands/han-solo/bootstrap.md` - Bootstrap command
  - `/commands/han-solo/ship.md` - Ship command
  - `/commands/han-solo/README.md` - Full documentation (NEW!)

This ensures users have all necessary documentation when installing han-solo tools.