### PR TITLE
fix: auto-enable GitHub Pages for Pages deployments in bootstrap

### DIFF
--- a/.claude/agents/bootstrap-guardian.md
+++ b/.claude/agents/bootstrap-guardian.md
@@ -545,6 +545,26 @@ YAML
 git add .github/workflows/ci.yml >/dev/null 2>&1 || true
 note "🏗️ CI workflow created with deployment strategy: $DEPLOY_TARGET"
 
+# Enable GitHub Pages if deploying to Pages
+if [ "$DEPLOY_TARGET" = "pages" ]; then
+  echo -e "\n${GREEN}Enabling GitHub Pages...${NC}"
+  
+  # Enable GitHub Pages on main branch with GitHub Actions source
+  if gh api -X PUT "repos/${OWNER_REPO}/pages" \
+    -f source='{"branch":"main","path":"/"}' \
+    -f build_type='workflow' >/dev/null 2>&1; then
+    note "📄 GitHub Pages enabled with GitHub Actions deployment"
+  else
+    # Try the newer API format if the old one fails
+    if gh api -X POST "repos/${OWNER_REPO}/pages" \
+      -f build_type='workflow' >/dev/null 2>&1; then
+      note "📄 GitHub Pages enabled with GitHub Actions deployment"
+    else
+      warn "Could not enable GitHub Pages (may need to be done manually)"
+    fi
+  fi
+fi
+
 # Create initialization workflow to establish status checks
 cat > .github/workflows/initialize-status-checks.yml <<'YAML'
 name: initialize-status-checks
@@ -773,5 +793,6 @@ trap report EXIT
   - PR-only triggers (no feature branch pushes)
   - Smart deployment detection (Pages/GHCR/Release)
   - GitHub releases for deployments
+- GitHub Pages auto-enabled for Pages deployments
 - Status check initialization via manual workflow
 - Clean git history with conventional commits


### PR DESCRIPTION
## 📋 Summary

This fix enhances the bootstrap-guardian agent to automatically enable GitHub Pages when it detects a Pages deployment target (React/Vue/Angular/Next.js projects). This prevents deployment failures by ensuring GitHub Pages is configured before the deployment workflow runs.

### 🐛 Bug Fixes
* fix: auto-enable GitHub Pages for Pages deployments in bootstrap

## 🎯 Changes Made

- Added automatic GitHub Pages detection and enablement in bootstrap-guardian
- Pages will be enabled when the agent detects compatible project types
- Prevents deployment workflow failures due to unconfigured Pages
- Maintains idempotent behavior - won't break existing Pages configurations

## 🧪 Impact

- Improves bootstrap reliability for web projects
- Reduces manual configuration steps for Pages deployments
- Better developer experience for solo developers using `/bootstrap`

---
_Generated from commit history by git-shipper_
