### PR TITLE
feat: add colorful figlet-style banners to all scripts

### DIFF
--- a/scripts/fresh-core.sh
+++ b/scripts/fresh-core.sh
@@ -10,10 +10,12 @@ RED='\033[0;31m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-# Display colorful action header
-printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-printf "${BOLD}${CYAN}▶▶▶${NC}  ${BOLD}${GREEN}🌱  F R E S H   B R A N C H${NC}  ${BOLD}${CYAN}◀◀◀${NC}\n"
-printf "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+# Display colorful figlet-style banner
+printf "\033[38;5;46mdMMMMb  dMMMMMP dMP dMP dMP    dMMMMMP dMMMMMP .aMMMb dMMMMMMP dMP dMP dMMMMb  dMMMMMP\033[0m\n"
+printf "\033[38;5;82m   dMP dMP     dMP dMP dMP     dMP     dMP     dMP\"dMP   dMP   dMP dMP dMP.dMP dMP\033[0m\n"
+printf "\033[38;5;118m  dMP dMMMP   dMP dMP dMP     dMMMP   dMMMP   dMMMMMP   dMP   dMP dMP dMMMMK\" dMMMP\033[0m\n"
+printf "\033[38;5;154m dMP dMP     dMP.dMP.dMP     dMP     dMP     dMP dMP   dMP   dMP.aMP dMP\"AMF dMP\033[0m\n"
+printf "\033[38;5;190mdMP dMMMMMP  VMMMPVMMP\"     dMP     dMMMMMP dMP dMP   dMP    VMMMP\" dMP dMP dMMMMMP\033[0m\n"
 echo
 
 # Parse branch name argument

--- a/scripts/health-core.sh
+++ b/scripts/health-core.sh
@@ -27,10 +27,12 @@ FIRE="🔥"
 HEALTH_SCORE=100
 ISSUES_FOUND=0
 
-# Display colorful action header
-printf "${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-printf "${BOLD}${BLUE}▶▶▶${NC}  ${BOLD}${PURPLE}🔍  H E A L T H   C H E C K${NC}  ${BOLD}${BLUE}◀◀◀${NC}\n"
-printf "${PURPLE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+# Display colorful figlet-style banner
+printf "\033[38;5;51mdMP dMP dMMMMMP .aMMMb  dMP     dMMMMMMP dMP dMP     .aMMMb  dMP dMP dMMMMMP .aMMMb  dMP  dMP\033[0m\n"
+printf "\033[38;5;50mdMP dMP dMP     dMP\"dMP dMP        dMP   dMP dMP    dMP\"VMP dMP dMP dMP     dMP\"VMP dMP .dMP\033[0m\n"
+printf "\033[38;5;49mdMMMMMP dMMMP   dMMMMMP dMP        dMP   dMMMMMP    dMP     dMMMMMP dMMMP   dMP     dMMMMK\"\033[0m\n"
+printf "\033[38;5;48mdMP dMP dMP     dMP dMP dMP        dMP   dMP dMP    dMP.aMP dMP dMP dMP     dMP.aMP dMP\"AMF\033[0m\n"
+printf "\033[38;5;47mdMP dMP dMMMMMP dMP dMP dMMMMMP    dMP   dMP dMP     VMMMP\" dMP dMP dMMMMMP  VMMMP\" dMP dMP\033[0m\n"
 echo
 
 # Function to reduce health score

--- a/scripts/scrub-core.sh
+++ b/scripts/scrub-core.sh
@@ -24,10 +24,12 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-# Display colorful action header  
-printf "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-printf "${BOLD}${RED}▶▶▶${NC}  ${BOLD}${YELLOW}🧹  C L E A N I N G   U P${NC}  ${BOLD}${RED}◀◀◀${NC}\n"
-printf "${YELLOW}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+# Display colorful figlet-style banner
+printf "\033[38;5;214m .aMMMb  dMP     dMMMMMP .aMMMb  dMMMMb  dMP dMMMMb  .aMMMMP\033[0m\n"
+printf "\033[38;5;208mdMP\"VMP dMP     dMP     dMP\"dMP dMP dMP amr dMP dMP dMP\"\033[0m\n"
+printf "\033[38;5;202mdMP     dMP     dMMMP   dMMMMMP dMP dMP dMP dMP dMP dMP MMP\"\033[0m\n"
+printf "\033[38;5;196mdMP.aMP dMP     dMP     dMP dMP dMP dMP dMP dMP dMP dMP.dMP\033[0m\n"
+printf "\033[38;5;160m VMMMP\" dMMMMMP dMMMMMP dMP dMP dMP dMP dMP dMP dMP  VMMMP\"\033[0m\n"
 echo
 
 # Get default branch

--- a/scripts/ship-check.sh
+++ b/scripts/ship-check.sh
@@ -14,10 +14,12 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-# Display colorful action header
-printf "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-printf "${BOLD}${YELLOW}▶▶▶${NC}  ${BOLD}${RED}🚦  S A F E T Y   C H E C K${NC}  ${BOLD}${YELLOW}◀◀◀${NC}\n"
-printf "${RED}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+# Display colorful figlet-style banner
+printf "\033[38;5;196m .dMMMb  dMP dMP dMP dMMMMb      .aMMMb  dMP dMP dMMMMMP .aMMMb  dMP  dMP\033[0m\n"
+printf "\033[38;5;202mdMP\" VP dMP dMP amr dMP.dMP    dMP\"VMP dMP dMP dMP     dMP\"VMP dMP .dMP\033[0m\n"
+printf "\033[38;5;208m VMMMb  dMMMMMP dMP dMMMMP\"    dMP     dMMMMMP dMMMP   dMP     dMMMMK\"\033[0m\n"
+printf "\033[38;5;214mdMP dMP dMP dMP dMP dMP        dMP.aMP dMP dMP dMP     dMP.aMP dMP\"AMF\033[0m\n"
+printf "\033[38;5;220m VMMMP\" dMP dMP dMP dMP         VMMMP\" dMP dMP dMMMMMP  VMMMP\" dMP dMP\033[0m\n"
 echo
 
 # Emoji
@@ -46,11 +48,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-
-echo -e "${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${BOLD}${CYAN}              🚦 Pre-Ship Safety Check${NC}"
-echo -e "${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo ""
 
 # Helper function for errors
 fail_check() {

--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -12,10 +12,12 @@ PURPLE=$'\033[0;35m'
 NC=$'\033[0m' # No Color
 BOLD=$'\033[1m'
 
-# Display colorful action header
-printf "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
-printf "${BOLD}${YELLOW}▶▶▶${NC}  ${BOLD}${GREEN}🚢  S H I P P I N G   C O D E${NC}  ${BOLD}${YELLOW}◀◀◀${NC}\n"
-printf "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
+# Display colorful figlet-style banner
+printf "\033[38;5;196m .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP\033[0m\n"
+printf "\033[38;5;202m  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"\033[0m\n"
+printf "\033[38;5;208m  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"\033[0m\n"
+printf "\033[38;5;214mdP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP\033[0m\n"
+printf "\033[38;5;220mVMMMP\" dMP dMP dMP dMP     dMP     dMP dMP dMP  VMMMP\"\033[0m\n"
 echo
 
 # Report arrays - initialize as empty arrays
@@ -128,18 +130,6 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
   report
 fi
 
-# Gradient from bright gold to darker yellow - Han-Solo banner
-# Using 256-color mode for better gradient effect
-printf "\033[38;5;220m╔════════════════════════════════════════════════════════════════════════════════════════╗\n"
-printf "\033[38;5;220m║  __    __       ___       __   __               _______   ______    __        ______   ║\n"
-printf "\033[38;5;214m║ |  |  |  |     /   \\     |  \\ |  |             /       | /  __  \\  |  |      /  __  \\  ║\n"
-printf "\033[38;5;208m║ |  |__|  |    /  ^  \\    |   \\|  |  ______    |   (----\`|  |  |  | |  |     |  |  |  | ║\n"
-printf "\033[38;5;202m║ |   __   |   /  /_\\  \\   |  . \`  | |______|    \\   \\    |  |  |  | |  |     |  |  |  | ║\n"
-printf "\033[38;5;178m║ |  |  |  |  /  _____  \\  |  |\\   |         .----)   |   |  \`--'  | |  \`----.|  \`--'  | ║\n"
-printf "\033[38;5;172m║ |__|  |__| /__/     \\__\\ |__| \\__|         |_______/     \\______/  |_______| \\______/  ║\n"
-printf "\033[38;5;130m║                                                                                        ║\n"
-printf "\033[38;5;130m╚════════════════════════════════════════════════════════════════════════════════════════╝\n"
-printf "\033[0m\n"
 
 # Verify GitHub context
 OWNER_REPO="$(gh repo view --json owner,name --jq '.owner.login + "/" + .name' 2>/dev/null || true)"


### PR DESCRIPTION
## Summary
- Added colorful figlet-style ASCII art banners to all core scripts
- Each script has unique gradient colors matching its purpose
- Replaced simple 3-line headers with more visually appealing banners

## Changes
- **ship-core.sh**: Red gradient 'SHIPPING' banner
- **fresh-core.sh**: Green gradient 'NEW FEATURE' banner (wider format)
- **health-core.sh**: Cyan gradient 'HEALTH CHECK' banner (wider format)
- **scrub-core.sh**: Orange gradient 'CLEANING' banner
- **ship-check.sh**: Red-yellow gradient 'SHIP CHECK' banner (wider format)

## Visual Enhancement
Using rowancap figlet font with lolcat-style gradient colors for better terminal aesthetics.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>