### PR TITLE
fix: align first line of figlet banner in ship-core.sh

### DIFF
--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -13,7 +13,7 @@ NC=$'\033[0m' # No Color
 BOLD=$'\033[1m'
 
 # Display colorful figlet-style banner
-printf "${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
+printf " ${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
 printf "${RED}  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"${NC}\n"
 printf "${YELLOW}  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"${NC}\n"
 printf "${YELLOW}dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP${NC}\n"


### PR DESCRIPTION
## Summary
- Add leading space to properly align the first line of the figlet-style banner with the rest of the banner text
- Improves visual consistency of the ship command banner output

## Test plan
- [x] Verify banner alignment in terminal output
- [x] Confirm no functional changes to ship workflow
- [x] All pre-commit and pre-push checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)