### PR TITLE
fix: only show figlet banners in TTY mode to prevent Error display

### DIFF
--- a/scripts/fresh-core.sh
+++ b/scripts/fresh-core.sh
@@ -10,13 +10,15 @@ RED='\033[0;31m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-# Display colorful figlet-style banner
-printf "${GREEN}dMMMMb  dMMMMMP dMP dMP dMP    dMMMMMP dMMMMMP .aMMMb dMMMMMMP dMP dMP dMMMMb  dMMMMMP${NC}\n"
-printf "${GREEN}   dMP dMP     dMP dMP dMP     dMP     dMP     dMP\"dMP   dMP   dMP dMP dMP.dMP dMP${NC}\n"
-printf "${CYAN}  dMP dMMMP   dMP dMP dMP     dMMMP   dMMMP   dMMMMMP   dMP   dMP dMP dMMMMK\" dMMMP${NC}\n"
-printf "${CYAN} dMP dMP     dMP.dMP.dMP     dMP     dMP     dMP dMP   dMP   dMP.aMP dMP\"AMF dMP${NC}\n"
-printf "${YELLOW}dMP dMMMMMP  VMMMPVMMP\"     dMP     dMMMMMP dMP dMP   dMP    VMMMP\" dMP dMP dMMMMMP${NC}\n"
-echo
+# Display colorful figlet-style banner only in TTY mode
+if [ -t 1 ]; then
+  printf "${GREEN}dMMMMb  dMMMMMP dMP dMP dMP    dMMMMMP dMMMMMP .aMMMb dMMMMMMP dMP dMP dMMMMb  dMMMMMP${NC}\n"
+  printf "${GREEN}   dMP dMP     dMP dMP dMP     dMP     dMP     dMP\"dMP   dMP   dMP dMP dMP.dMP dMP${NC}\n"
+  printf "${CYAN}  dMP dMMMP   dMP dMP dMP     dMMMP   dMMMP   dMMMMMP   dMP   dMP dMP dMMMMK\" dMMMP${NC}\n"
+  printf "${CYAN} dMP dMP     dMP.dMP.dMP     dMP     dMP     dMP dMP   dMP   dMP.aMP dMP\"AMF dMP${NC}\n"
+  printf "${YELLOW}dMP dMMMMMP  VMMMPVMMP\"     dMP     dMMMMMP dMP dMP   dMP    VMMMP\" dMP dMP dMMMMMP${NC}\n"
+  echo
+fi
 
 # Parse branch name argument
 BRANCH_NAME="${1:-feature/$(date +%Y-%m-%d-%H%M%S)}"

--- a/scripts/health-core.sh
+++ b/scripts/health-core.sh
@@ -27,13 +27,15 @@ FIRE="🔥"
 HEALTH_SCORE=100
 ISSUES_FOUND=0
 
-# Display colorful figlet-style banner
-printf "${CYAN}dMP dMP dMMMMMP .aMMMb  dMP     dMMMMMMP dMP dMP     .aMMMb  dMP dMP dMMMMMP .aMMMb  dMP  dMP${NC}\n"
-printf "${CYAN}dMP dMP dMP     dMP\"dMP dMP        dMP   dMP dMP    dMP\"VMP dMP dMP dMP     dMP\"VMP dMP .dMP${NC}\n"
-printf "${BLUE}dMMMMMP dMMMP   dMMMMMP dMP        dMP   dMMMMMP    dMP     dMMMMMP dMMMP   dMP     dMMMMK\"${NC}\n"
-printf "${BLUE}dMP dMP dMP     dMP dMP dMP        dMP   dMP dMP    dMP.aMP dMP dMP dMP     dMP.aMP dMP\"AMF${NC}\n"
-printf "${PURPLE}dMP dMP dMMMMMP dMP dMP dMMMMMP    dMP   dMP dMP     VMMMP\" dMP dMP dMMMMMP  VMMMP\" dMP dMP${NC}\n"
-echo
+# Display colorful figlet-style banner only in TTY mode
+if [ -t 1 ]; then
+  printf "${CYAN}dMP dMP dMMMMMP .aMMMb  dMP     dMMMMMMP dMP dMP     .aMMMb  dMP dMP dMMMMMP .aMMMb  dMP  dMP${NC}\n"
+  printf "${CYAN}dMP dMP dMP     dMP\"dMP dMP        dMP   dMP dMP    dMP\"VMP dMP dMP dMP     dMP\"VMP dMP .dMP${NC}\n"
+  printf "${BLUE}dMMMMMP dMMMP   dMMMMMP dMP        dMP   dMMMMMP    dMP     dMMMMMP dMMMP   dMP     dMMMMK\"${NC}\n"
+  printf "${BLUE}dMP dMP dMP     dMP dMP dMP        dMP   dMP dMP    dMP.aMP dMP dMP dMP     dMP.aMP dMP\"AMF${NC}\n"
+  printf "${PURPLE}dMP dMP dMMMMMP dMP dMP dMMMMMP    dMP   dMP dMP     VMMMP\" dMP dMP dMMMMMP  VMMMP\" dMP dMP${NC}\n"
+  echo
+fi
 
 # Function to reduce health score
 reduce_health() {

--- a/scripts/scrub-core.sh
+++ b/scripts/scrub-core.sh
@@ -24,13 +24,15 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-# Display colorful figlet-style banner
-printf "${YELLOW} .aMMMb  dMP     dMMMMMP .aMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
-printf "${YELLOW}dMP\"VMP dMP     dMP     dMP\"dMP dMP dMP amr dMP dMP dMP\"${NC}\n"
-printf "${RED}dMP     dMP     dMMMP   dMMMMMP dMP dMP dMP dMP dMP dMP MMP\"${NC}\n"
-printf "${RED}dMP.aMP dMP     dMP     dMP dMP dMP dMP dMP dMP dMP dMP.dMP${NC}\n"
-printf "${GREEN} VMMMP\" dMMMMMP dMMMMMP dMP dMP dMP dMP dMP dMP dMP  VMMMP\"${NC}\n"
-echo
+# Display colorful figlet-style banner only in TTY mode
+if [ -t 1 ]; then
+  printf "${YELLOW} .aMMMb  dMP     dMMMMMP .aMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
+  printf "${YELLOW}dMP\"VMP dMP     dMP     dMP\"dMP dMP dMP amr dMP dMP dMP\"${NC}\n"
+  printf "${RED}dMP     dMP     dMMMP   dMMMMMP dMP dMP dMP dMP dMP dMP MMP\"${NC}\n"
+  printf "${RED}dMP.aMP dMP     dMP     dMP dMP dMP dMP dMP dMP dMP dMP.dMP${NC}\n"
+  printf "${GREEN} VMMMP\" dMMMMMP dMMMMMP dMP dMP dMP dMP dMP dMP dMP  VMMMP\"${NC}\n"
+  echo
+fi
 
 # Get default branch
 DEFAULT=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || echo 'main')

--- a/scripts/ship-check.sh
+++ b/scripts/ship-check.sh
@@ -14,13 +14,15 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-# Display colorful figlet-style banner
-printf "${RED} .dMMMb  dMP dMP dMP dMMMMb      .aMMMb  dMP dMP dMMMMMP .aMMMb  dMP  dMP${NC}\n"
-printf "${RED}dMP\" VP dMP dMP amr dMP.dMP    dMP\"VMP dMP dMP dMP     dMP\"VMP dMP .dMP${NC}\n"
-printf "${YELLOW} VMMMb  dMMMMMP dMP dMMMMP\"    dMP     dMMMMMP dMMMP   dMP     dMMMMK\"${NC}\n"
-printf "${YELLOW}dMP dMP dMP dMP dMP dMP        dMP.aMP dMP dMP dMP     dMP.aMP dMP\"AMF${NC}\n"
-printf "${GREEN} VMMMP\" dMP dMP dMP dMP         VMMMP\" dMP dMP dMMMMMP  VMMMP\" dMP dMP${NC}\n"
-echo
+# Display colorful figlet-style banner only in TTY mode
+if [ -t 1 ]; then
+  printf "${RED} .dMMMb  dMP dMP dMP dMMMMb      .aMMMb  dMP dMP dMMMMMP .aMMMb  dMP  dMP${NC}\n"
+  printf "${RED}dMP\" VP dMP dMP amr dMP.dMP    dMP\"VMP dMP dMP dMP     dMP\"VMP dMP .dMP${NC}\n"
+  printf "${YELLOW} VMMMb  dMMMMMP dMP dMMMMP\"    dMP     dMMMMMP dMMMP   dMP     dMMMMK\"${NC}\n"
+  printf "${YELLOW}dMP dMP dMP dMP dMP dMP        dMP.aMP dMP dMP dMP     dMP.aMP dMP\"AMF${NC}\n"
+  printf "${GREEN} VMMMP\" dMP dMP dMP dMP         VMMMP\" dMP dMP dMMMMMP  VMMMP\" dMP dMP${NC}\n"
+  echo
+fi
 
 # Emoji
 CHECK="✅"

--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -12,13 +12,15 @@ PURPLE=$'\033[0;35m'
 NC=$'\033[0m' # No Color
 BOLD=$'\033[1m'
 
-# Display colorful figlet-style banner
-printf " ${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
-printf "${RED}  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"${NC}\n"
-printf "${YELLOW}  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"${NC}\n"
-printf "${YELLOW}dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP${NC}\n"
-printf "${GREEN}VMMMP\" dMP dMP dMP dMP     dMP     dMP dMP dMP  VMMMP\"${NC}\n"
-echo
+# Display colorful figlet-style banner only in TTY mode
+if [ -t 1 ]; then
+  printf " ${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
+  printf "${RED}  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"${NC}\n"
+  printf "${YELLOW}  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"${NC}\n"
+  printf "${YELLOW}dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP${NC}\n"
+  printf "${GREEN}VMMMP\" dMP dMP dMP dMP     dMP     dMP dMP dMP  VMMMP\"${NC}\n"
+  echo
+fi
 
 # Report arrays - initialize as empty arrays
 declare -a INFO=()


### PR DESCRIPTION
Fixes TTY detection for figlet banners to prevent display issues in non-TTY environments.