### PR TITLE
fix: remove leading space from first figlet banner line

### DIFF
--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -14,7 +14,7 @@ BOLD=$'\033[1m'
 
 # Display colorful figlet-style banner only in TTY mode
 if [ -t 1 ]; then
-  printf " ${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
+  printf "${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
   printf "${RED}  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"${NC}\n"
   printf "${YELLOW}  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"${NC}\n"
   printf "${YELLOW}dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP${NC}\n"


### PR DESCRIPTION
Minor formatting fix to align the first line of the figlet banner properly by removing the leading space.

This improves the visual alignment of the ship command's banner display.