### PR TITLE
docs: change 'in TTY mode' to 'using TTY mode' in comment

### DIFF
--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -12,7 +12,7 @@ PURPLE=$'\033[0;35m'
 NC=$'\033[0m' # No Color
 BOLD=$'\033[1m'
 
-# Display colorful figlet-style banner only in TTY mode
+# Display colorful figlet-style banner only using TTY mode
 if [ -t 1 ]; then
   printf "${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
   printf "${RED}  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"${NC}\n"


### PR DESCRIPTION
## Summary
Minor documentation improvement for clarity in figlet banner comment.

Changes 'in TTY mode' to 'using TTY mode' in the comment explaining when colorful figlet-style banners are displayed.

## Test plan
- [x] Comment change is purely documentation
- [x] No functional changes
- [x] Pre-commit hooks passed (format, lint)
- [x] Pre-push hooks passed (typecheck, test, build)

🤖 Generated with [Claude Code](https://claude.ai/code)