### PR TITLE
fix: remove colors from ASCII banner in ship-core.sh

### DIFF
--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -12,13 +12,13 @@ PURPLE=$'\033[0;35m'
 NC=$'\033[0m' # No Color
 BOLD=$'\033[1m'
 
-# Display colorful figlet-style banner only using TTY mode
+# Display figlet-style banner only in TTY mode (no colors)
 if [ -t 1 ]; then
-  printf "${RED} .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP${NC}\n"
-  printf "${RED}  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"${NC}\n"
-  printf "${YELLOW}  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"${NC}\n"
-  printf "${YELLOW}dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP${NC}\n"
-  printf "${GREEN}VMMMP\" dMP dMP dMP dMP     dMP     dMP dMP dMP  VMMMP\"${NC}\n"
+  printf " .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP\n"
+  printf "  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"\n"
+  printf "  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"\n"
+  printf "dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP\n"
+  printf "VMMMP\" dMP dMP dMP dMP     dMP     dMP dMP dMP  VMMMP\"\n"
   echo
 fi
 


### PR DESCRIPTION
The ASCII banner in ship-core.sh now displays in plain text without color formatting for better compatibility across terminals.

## Changes
- Removed color variables from ASCII banner output
- Updated comment to reflect plain text display
- Banner still only shows in TTY mode

## Test Plan
- Verify banner displays correctly without colors
- Confirm TTY detection still works properly