### PR TITLE
Remove TTY check from figlet banner display

### DIFF
--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -12,15 +12,13 @@ PURPLE=$'\033[0;35m'
 NC=$'\033[0m' # No Color
 BOLD=$'\033[1m'
 
-# Display figlet-style banner only in TTY mode (no colors)
-if [ -t 1 ]; then
-  printf " .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP\n"
-  printf "  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"\n"
-  printf "  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"\n"
-  printf "dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP\n"
-  printf "VMMMP\" dMP dMP dMP dMP     dMP     dMP dMP dMP  VMMMP\"\n"
-  echo
-fi
+# Display figlet-style banner (no colors)
+printf " .dMMMb  dMP dMP dMP dMMMMb  dMMMMb  dMP dMMMMb  .aMMMMP\n"
+printf "  dMP\" VP dMP dMP amr dMP.dMP dMP.dMP amr dMP dMP dMP\"\n"
+printf "  VMMMb  dMMMMMP dMP dMMMMP\" dMMMMP\" dMP dMP dMP dMP MMP\"\n"
+printf "dP .dMP dMP dMP dMP dMP     dMP     dMP dMP dMP dMP.dMP\n"
+printf "VMMMP\" dMP dMP dMP dMP     dMP     dMP dMP dMP  VMMMP\"\n"
+echo
 
 # Report arrays - initialize as empty arrays
 declare -a INFO=()


### PR DESCRIPTION
## 📋 Summary

This PR removes the TTY check from the figlet banner display in ship-core.sh, ensuring the banner always displays regardless of terminal mode.

### 🐛 Bug Fixes
* fix: remove TTY check from figlet banner display

## Changes
- Removed the if [ -t 1 ]; then condition around the figlet banner
- Banner will now display consistently in all environments including CI/CD and non-interactive shells
- Maintains the same visual appearance while improving consistency

This ensures the han-solo banner appears in all execution contexts, providing better user experience and consistency across different environments.

---
_Generated by han-solo_