### PR TITLE
fix: redirect git fetch stderr to prevent false error indication

### DIFF
--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -143,7 +143,7 @@ note "🌿 Default branch: $DEFAULT"
 
 # Fetch latest changes
 echo -e "\n${GREEN}Syncing with remote...${NC}"
-git fetch --prune --tags || warn "Failed to fetch from remote"
+git fetch --prune --tags 2>&1 || warn "Failed to fetch from remote"
 
 # Get current branch
 CURR_BRANCH="$(git branch --show-current 2>/dev/null || true)"


### PR DESCRIPTION
## Summary
- Fixed false 'Error:' prefix appearing when ship-core.sh runs
- The issue was caused by git fetch --prune outputting branch deletion messages to stderr

## Problem
When `git fetch --prune --tags` runs, it outputs informational messages about deleted branches to stderr:
```
From https://github.com/slamb2k/han-solo
- [deleted]         (none)     -> origin/Banner-Fixes
```

The Bash tool interprets any stderr output as an error, causing the entire output to be prefixed with 'Error:' even though the command succeeds.

## Solution
Redirect stderr to stdout (2>&1) for the git fetch command so these informational messages appear as normal output instead of triggering the error indication.

## Test plan
- [x] Run ship-core.sh and verify no false 'Error:' prefix appears
- [x] Verify actual errors are still captured and reported
- [x] Confirm branch pruning still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)