### PR TITLE
fix: prevent ship-core.sh from hanging on git fetch

### DIFF
--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -143,11 +143,16 @@ note "🌿 Default branch: $DEFAULT"
 
 # Fetch latest changes
 echo -e "\n${GREEN}Syncing with remote...${NC}"
-# Redirect all output to null and check status separately
-if git fetch --prune --tags >/dev/null 2>&1; then
+# Use timeout to prevent hanging, redirect output to avoid stderr issues
+if timeout 5 git fetch --prune --tags >/dev/null 2>&1; then
   debug "Successfully fetched from remote"
 else
-  warn "Failed to fetch from remote"
+  # Check if it was a timeout or actual failure
+  if [ $? -eq 124 ]; then
+    warn "Git fetch timed out - continuing anyway"
+  else
+    warn "Failed to fetch from remote"
+  fi
 fi
 
 # Get the current branch

--- a/scripts/ship-core.sh
+++ b/scripts/ship-core.sh
@@ -143,9 +143,14 @@ note "🌿 Default branch: $DEFAULT"
 
 # Fetch latest changes
 echo -e "\n${GREEN}Syncing with remote...${NC}"
-git fetch --prune --tags 2>&1 || warn "Failed to fetch from remote"
+# Redirect all output to null and check status separately
+if git fetch --prune --tags >/dev/null 2>&1; then
+  debug "Successfully fetched from remote"
+else
+  warn "Failed to fetch from remote"
+fi
 
-# Get current branch
+# Get the current branch
 CURR_BRANCH="$(git branch --show-current 2>/dev/null || true)"
 debug "Current branch: $CURR_BRANCH"
 


### PR DESCRIPTION
## Summary
- Fixed ship-core.sh hanging indefinitely during git fetch
- Suppressed git branch pruning messages to prevent false error indications
- Added 5-second timeout to git fetch operations

## Problems Fixed

### 1. False Error Indication
When `git fetch --prune` runs, it outputs branch deletion messages to stderr:
```
From https://github.com/slamb2k/han-solo
- [deleted]         (none)     -> origin/Banner-Fixes
```
These appeared as errors even though they're just informational.

### 2. Git Fetch Hanging
The `git fetch` command would sometimes hang indefinitely, causing ship-core.sh to never complete.

## Solutions

1. **Redirect output to /dev/null** - Suppresses pruning messages entirely
2. **Add 5-second timeout** - Prevents hanging with `timeout 5 git fetch`
3. **Handle timeout gracefully** - Distinguishes between timeout (exit code 124) and actual failures

## Test plan
- [x] Run ship-core.sh --check to verify no hanging
- [x] Test with various flags (--nowait, etc.)
- [x] Verify timeout works and execution continues
- [x] Confirm no false error messages appear

🤖 Generated with [Claude Code](https://claude.ai/code)